### PR TITLE
feat(argo): add server secret for argo

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -3,3 +3,6 @@ extends: default
 rules:
   line-length: disable
   document-start: disable
+  indentation:
+    spaces: consistent
+    indent-sequences: false

--- a/apis/xenvironments/definition.yaml
+++ b/apis/xenvironments/definition.yaml
@@ -80,6 +80,9 @@ spec:
                       createCtp:
                         type: boolean
                         default: true
+                      createArgoSecret:
+                        type: boolean
+                        default: true
                       secretSync:
                         type: array
                         items:

--- a/functions/xenvironments/argo/secret.k
+++ b/functions/xenvironments/argo/secret.k
@@ -1,0 +1,55 @@
+import models.io.crossplane.kubernetes.v1alpha2 as kubernetesv1alpha2
+import kube.api.core.v1 as v1
+import utils
+import json
+
+argoServerSecret = lambda config: ArgoServerSecret -> any {
+   """
+   Creates a ArgoCD Server Secret.
+   """
+   [
+        kubernetesv1alpha2.Object{
+            metadata = utils._metadata("ctp-argocd") | {
+                name = "{}-ctp-argocd-secret".format(config.ctp)
+            }
+            spec = {
+                forProvider = {
+                    manifest = v1.Secret{
+                        metadata: {
+                            name: "{}-{}".format(config.group,config.ctp)
+                            namespace: "argocd"
+                            labels: {
+                                "argocd.argoproj.io/secret-type": "cluster"
+                            }
+                        }
+                        type: "Opaque"
+                        stringData: {
+                            name: "{}-{}".format(config.group,config.ctp)
+                            server: "https://{}/apis/spaces.upbound.io/v1beta1/namespaces/{}/controlplanes/{}/k8s".format(config.spaceHost, config.group, config.ctp)
+                            config: json.encode({
+                                execProviderConfig: {
+                                    apiVersion: "client.authentication.k8s.io/v1"
+                                    command: "up"
+                                    args: [
+                                        "org"
+                                        "token"
+                                    ]
+                                    env: {
+                                        "ORGANIZATION": config.org
+                                        "UP_TOKEN": config.accessToken
+                                    }
+                                }
+                                tlsClientConfig: {
+                                    insecure: False
+                                    caData: config.serverCaData
+                                }
+                            })
+                        }
+                    }
+                }
+                providerConfigRef = {
+                    name = config.providerConfigName
+                }
+            }
+        }
+]}

--- a/functions/xenvironments/argo/secretSchema.k
+++ b/functions/xenvironments/argo/secretSchema.k
@@ -1,0 +1,29 @@
+schema ArgoServerSecret:
+    r"""
+    ArgoServerSecret represents an Input for an Argo Server Secret.
+
+    Attributes
+    ----------
+    spaceHost : str, required
+        The Upbound Spaces host (e.g. spaces.upbound.io)
+    org : str, required
+        The Upbound organization name
+    group : str, required
+        The group name for group-level access
+    ctp : str, required
+        The control plane name for control plane-level access
+    providerConfigName : str, required
+        The Name of the provider config to reference
+    accessToken : str, required
+        The AccessToken (PersonalAccessToken or RobotToken)
+    serverCaData : str, required
+        The ServerCaData as base64 encoded string
+    """
+
+    spaceHost: str
+    org: str
+    group: str
+    ctp: str
+    providerConfigName: str
+    accessToken: str
+    serverCaData: str

--- a/functions/xenvironments/aws/crossplaneRole.k
+++ b/functions/xenvironments/aws/crossplaneRole.k
@@ -10,10 +10,7 @@ to and manage AWS services. It creates:
 """
 
 import models.io.upbound.aws.iam.v1beta1 as iamv1beta1
-
-_metadata = lambda name: str -> any {
-    { annotations = { "krm.kcl.dev/composition-resource-name" = name }}
-}
+import utils
 
 schema AWSXPRoleInput:
     """
@@ -43,7 +40,7 @@ getXPRoleItems = lambda awsParams: AWSXPRoleInput -> [any] {
     """
     [
     iamv1beta1.Role {
-        metadata = _metadata("iamAdminRole") | {
+        metadata = utils._metadata("iamAdminRole") | {
             name = "{}-admin".format(awsParams.namePrefix)
         }
         spec = {
@@ -74,7 +71,7 @@ getXPRoleItems = lambda awsParams: AWSXPRoleInput -> [any] {
         }
     }
     iamv1beta1.RolePolicyAttachment {
-        metadata = _metadata("iamAdminRoleAttach") | {
+        metadata = utils._metadata("iamAdminRoleAttach") | {
             name = "{}-admin".format(awsParams.namePrefix)
         }
         spec = {
@@ -91,7 +88,7 @@ getXPRoleItems = lambda awsParams: AWSXPRoleInput -> [any] {
         }
     }
     iamv1beta1.OpenIDConnectProvider {
-        metadata = _metadata("upboundOidcProvider") | {
+        metadata = utils._metadata("upboundOidcProvider") | {
             name = "{}-oidc-provider".format(awsParams.namePrefix)
             annotations = {
                 if awsParams.oidcProviderArn:

--- a/functions/xenvironments/aws/providerConfig.k
+++ b/functions/xenvironments/aws/providerConfig.k
@@ -1,8 +1,5 @@
 import models.io.upbound.aws.v1beta1 as awsv1beta1
-
-_metadata = lambda name: str -> any {
-    { annotations = { "krm.kcl.dev/composition-resource-name" = name }}
-}
+import utils
 
 schema AWSProviderConfigInput:
     awsCredsSecretRef?: awsv1beta1.AwsUpboundIoV1beta1ProviderConfigSpecCredentialsSecretRef
@@ -11,7 +8,7 @@ schema AWSProviderConfigInput:
 
 getProviderConfig = lambda awsParams: AWSProviderConfigInput -> [any] {[
     awsv1beta1.ProviderConfig{
-        metadata = _metadata("awsProviderConfig") | {
+        metadata = utils._metadata("awsProviderConfig") | {
             name = awsParams.envName
             annotations = {
               "krm.kcl.dev/ready" = "True"

--- a/functions/xenvironments/aws/secretStore.k
+++ b/functions/xenvironments/aws/secretStore.k
@@ -2,9 +2,7 @@ import models.io.upbound.aws.iam.v1beta1 as iamv1beta1
 import models.io.upbound.aws.secretsmanager.v1beta1 as secretsmanagerv1beta1
 import models.io.crossplane.kubernetes.v1alpha2 as kubernetesv1alpha2
 import spaces.v1alpha1 as spacesv1alpha1
-_metadata = lambda name: str -> any {
-    { annotations = { "krm.kcl.dev/composition-resource-name" = name }}
-}
+import utils
 
 schema AWSSecretStoreInput:
     accountId: str
@@ -20,7 +18,7 @@ schema AWSSecretStoreInput:
 getSecretStoreItems = lambda awsParams: AWSSecretStoreInput -> [any] {[
     ### Needed until SharedSecretStore supports IAM Roles ###
     iamv1beta1.User {
-        metadata = _metadata("iamUserSecretRead") | {
+        metadata = utils._metadata("iamUserSecretRead") | {
             name = "{}-secrets-read".format(awsParams.namePrefix)
         }
         spec = {
@@ -32,7 +30,7 @@ getSecretStoreItems = lambda awsParams: AWSSecretStoreInput -> [any] {[
         }
     }
     iamv1beta1.Policy {
-        metadata = _metadata("iamPolicySecretRead") | {
+        metadata = utils._metadata("iamPolicySecretRead") | {
             name = "{}-secrets-read".format(awsParams.namePrefix)
         }
         spec = {
@@ -61,7 +59,7 @@ getSecretStoreItems = lambda awsParams: AWSSecretStoreInput -> [any] {[
         }
     }
     iamv1beta1.UserPolicyAttachment {
-        metadata = _metadata("iamPolicySecretReadAttach") | {
+        metadata = utils._metadata("iamPolicySecretReadAttach") | {
             name = "{}-secrets-read".format(awsParams.namePrefix)
         }
         spec = {
@@ -80,7 +78,7 @@ getSecretStoreItems = lambda awsParams: AWSSecretStoreInput -> [any] {[
         }
     }
     iamv1beta1.AccessKey {
-        metadata = _metadata("iamUserAccessKey") | {
+        metadata = utils._metadata("iamUserAccessKey") | {
             name = "{}-secrets-read".format(awsParams.namePrefix)
         }
         spec = {
@@ -101,7 +99,7 @@ getSecretStoreItems = lambda awsParams: AWSSecretStoreInput -> [any] {[
     }
     # copy the iam access key secret
     kubernetesv1alpha2.Object{
-        metadata = _metadata("envIamUserKeySecret") | {
+        metadata = utils._metadata("envIamUserKeySecret") | {
             name = "{}-secrets-read-access-key".format(awsParams.envName)
         }
         spec = {
@@ -135,7 +133,7 @@ getSecretStoreItems = lambda awsParams: AWSSecretStoreInput -> [any] {[
     }
     ### end iam user workaroung ###
     secretsmanagerv1beta1.Secret {
-        metadata = _metadata("secretsmanagerSecret") | {
+        metadata = utils._metadata("secretsmanagerSecret") | {
             name = "{}-secretsmanager-secret".format(awsParams.namePrefix)
             annotations = {
                 if awsParams.secretsManagerSecretArn:
@@ -157,7 +155,7 @@ getSecretStoreItems = lambda awsParams: AWSSecretStoreInput -> [any] {[
     }
     # Shared secret store mapped to secret on cloud-provider
     kubernetesv1alpha2.Object{
-        metadata = _metadata("sharedSecretsStore") | {
+        metadata = utils._metadata("sharedSecretsStore") | {
             name = "{}-sss".format(awsParams.ctpName)
         }
         spec = {
@@ -205,7 +203,7 @@ getSecretStoreItems = lambda awsParams: AWSSecretStoreInput -> [any] {[
     # Shared secret which will populate initial secret from cloud into
     # the main controlplane of the environment
     kubernetesv1alpha2.Object{
-        metadata = _metadata("sharedExternalSecret") | {
+        metadata = utils._metadata("sharedExternalSecret") | {
             name = "{}-ses".format(awsParams.ctpName)
         }
         spec = {

--- a/functions/xenvironments/bootstrapSecretSync.k
+++ b/functions/xenvironments/bootstrapSecretSync.k
@@ -10,6 +10,7 @@ Schemas:
 """
 
 import models.io.crossplane.kubernetes.v1alpha2 as kubernetesv1alpha2
+import utils
 
 schema SecretRef:
     """
@@ -34,19 +35,6 @@ schema SecretSyncInput:
     destRef: SecretRef
     providerConfigName: str
 
-_metadata = lambda name: str -> any {
-    """
-    Creates metadata with a standardized composition resource name.
-
-    Args:
-        name: The name to include in the annotations
-
-    Returns:
-        A metadata object with annotations for composition resource naming
-    """
-    { annotations = { "krm.kcl.dev/composition-resource-name" = name }}
-}
-
 syncedSecrets = lambda input: [SecretSyncInput] -> any {
     """
     Creates Crossplane Kubernetes provider objects to sync secrets from bootstrap to environments.
@@ -64,7 +52,7 @@ syncedSecrets = lambda input: [SecretSyncInput] -> any {
     [
         # Copy secret from bootstrap-ctp into destination-ctp
         kubernetesv1alpha2.Object {
-            metadata = _metadata("{}-{}-to-{}-{}-syncedSecret".format(
+            metadata = utils._metadata("{}-{}-to-{}-{}-syncedSecret".format(
                 secret.sourceRef.namespace, secret.sourceRef.name,
                 secret.destRef.namespace, secret.destRef.name))
             spec = {

--- a/functions/xenvironments/kcl.mod
+++ b/functions/xenvironments/kcl.mod
@@ -5,3 +5,4 @@ version = "0.0.1"
 [dependencies]
 models = { path = "./model" }
 spaces = { oci = "oci://xpkg.upbound.io/upbound/kcl-modules_spaces", tag = "1.12.0", package = "kcl-modules_spaces", version = "1.12.0" }
+kube = { oci = "oci://xpkg.upbound.io/upbound/kcl-modules_kube", tag = "1.31.2", package = "kcl-modules_kube", version = "1.31.2" }

--- a/functions/xenvironments/kcl.mod.lock
+++ b/functions/xenvironments/kcl.mod.lock
@@ -1,4 +1,12 @@
 [dependencies]
+  [dependencies.kube]
+    name = "kube"
+    full_name = "kcl-modules_kube_1.31.2"
+    version = "1.31.2"
+    sum = "y64lh34Xf5Q153ztr9PCv1tk68PooVslN7vIc+hg1Rw="
+    reg = "xpkg.upbound.io"
+    repo = "upbound/kcl-modules_kube"
+    oci_tag = "1.31.2"
   [dependencies.models]
     name = "models"
     full_name = "models_0.0.1"

--- a/functions/xenvironments/main.k
+++ b/functions/xenvironments/main.k
@@ -4,6 +4,7 @@ It automates the creation and management of Upbound Spaces environments with
 integrated AWS cloud resources. The function handles:
 - Environment initialization using bootstrap credentials
 - Control plane creation in Upbound Spaces
+- Server Secret for Argo
 - Kubernetes provider configurations for various scopes (space/group/control plane)
 - AWS IAM role and policy setup for cross-service authentication
 - Secret management between AWS Secrets Manager and Upbound Spaces
@@ -24,6 +25,8 @@ import aws.crossplaneRole as awsXPRole
 import pKubernetesHelper
 import teamRobot
 import bootstrapSecretSync
+import argo
+import utils
 
 oxr = option("params").oxr # observed composite resource
 ocds = option("params").ocds # observed composed resources
@@ -32,10 +35,6 @@ dcds = option("params").dcds # desired composed resources
 
 oxrMeta =  sav1.XEnvironment.metadata{**oxr.metadata}
 oxrSpec =  sav1.XEnvironment.spec{**oxr.spec}
-
-_metadata = lambda name: str -> any {
-    { annotations = { "krm.kcl.dev/composition-resource-name" = name }}
-}
 
 # =========================================================================
 # Initial Kubeconfig Processing
@@ -51,6 +50,7 @@ _metadata = lambda name: str -> any {
 # 3. Creates resources only after the metadata is properly established
 
 _initKubeconfigServerUrl = Undefined
+_initKubeconfigServerCaData = Undefined
 _upboundSpaceHostFromKubeconfig = Undefined
 _upboundBootstrapGroupFromKubeconfig = Undefined
 _upboundBootstrapCtpFromKubeconfig = Undefined
@@ -61,6 +61,7 @@ _upboundOrgFromKubeconfig = Undefined
 _initialKubeconfig = ocds.observedCtpKubeconfig?.Resource?.status?.atProvider?.manifest?.data?.kubeconfig
 if _initialKubeconfig:
     _initKubeconfigServerUrl = yaml.decode(base64.decode(_initialKubeconfig)).clusters[0]?.cluster?.server
+    _initKubeconfigServerCaData = yaml.decode(base64.decode(_initialKubeconfig)).clusters[0]?.cluster?["certificate-authority-data"]
     _upboundSpaceHostFromKubeconfig = regex.replace(_initKubeconfigServerUrl, "https:\/\/([.\w-]+)(?:\/[.\w-]+){8}", "$1")
     _upboundBootstrapGroupFromKubeconfig = regex.replace(_initKubeconfigServerUrl, "https:\/(?:\/[.\w-]+){5}\/([.\w-]+)(?:\/[.\w-]+){3}", "$1")
     _upboundBootstrapCtpFromKubeconfig = regex.replace(_initKubeconfigServerUrl, "https:\/(?:\/[.\w-]+){7}\/([.\w-]+)(?:\/[.\w-]+)", "$1")
@@ -90,7 +91,7 @@ _initItems = [
     # observed kubeconfig for bootstrap-ctp, will be used to derive settings
     # like upbound org, bootstrap-group, bootstrap-controlplane and space host
     kubernetesv1alpha2.Object{
-        metadata = _metadata("observedCtpKubeconfig") | {
+        metadata = utils._metadata("observedCtpKubeconfig") | {
             name = "{}-bootstrap-ctp-kubeconfig-observed".format(oxrMeta.name)
         }
         spec = {
@@ -134,7 +135,7 @@ if _initReady:
         # Main controlplane for the environment
         if oxrSpec.parameters.upbound.createCtp:
             kubernetesv1alpha2.Object{
-                metadata = _metadata("ctp") | {
+                metadata = utils._metadata("ctp") | {
                     name = "{}-ctp".format(oxrMeta.name)
                 }
                 spec = {
@@ -171,13 +172,10 @@ if _initReady:
 
         if oxrSpec.parameters.upbound.createGroup:
             kubernetesv1alpha2.Object{
-                metadata = _metadata("envGroup") | {
+                metadata = utils._metadata("envGroup") | {
                     name = envGroupName
                 }
                 spec = {
-                    readiness: {
-                        policy: "DeriveFromObject"
-                    }
                     deletionPolicy = oxrSpec.parameters.deletionPolicy
                     forProvider = {
                         manifest = {
@@ -194,6 +192,33 @@ if _initReady:
                 }
             }
     ]
+    if oxrSpec.parameters.upbound.createArgoSecret:
+        # =========================================================================
+        # Argo Server Secret Creation
+        # =========================================================================
+        # - Observe the Access Token (PersonalAccessToken or RobotToken)
+        # - Create Argo Server Secret when Access Token is available
+
+        _upboundItems += utils.observeSecret(utils.ObserveSecret{
+            ctp = oxrMeta.name
+            name = oxrSpec.parameters.upbound.tokenSecretRef.name
+            namespace = oxrSpec.parameters.upbound.tokenSecretRef.namespace
+            providerConfigName = "{}-ctp".format(_oxrStatusUpbound.bootstrapCtp)
+            resourceName = "observed-access-token"
+        })
+
+        _accessToken = base64.decode(ocds["observed-access-token"]?.Resource?.status?.atProvider?.manifest?.data?.token)
+        if _accessToken:
+            _upboundItems += argo.argoServerSecret(argo.ArgoServerSecret{
+                accessToken: _accessToken
+                org = _oxrStatusUpbound.org
+                group = envGroupName
+                ctp = oxrMeta.name
+                providerConfigName: "{}-ctp".format(_oxrStatusUpbound.bootstrapCtp)
+                serverCaData: _initKubeconfigServerCaData
+                spaceHost = _oxrStatusUpbound.spaceHost
+            })
+
     if oxrSpec.parameters.upbound.createCtp:
         _upboundItems += pKubernetesHelper.upboundProviderConfig(pKubernetesHelper.UpboundProviderConfigInput{
             # controlplane level providerconfig for provider-kubernetes

--- a/functions/xenvironments/pKubernetesHelper.k
+++ b/functions/xenvironments/pKubernetesHelper.k
@@ -10,6 +10,7 @@ This module supports creating provider configurations at different scopes:
 
 import models.io.crossplane.kubernetes.v1alpha2 as kubernetesv1alpha2
 import models.io.crossplane.kubernetes.v1alpha1 as kubernetesv1alpha1
+import utils
 
 schema UpboundTokenSecretRef:
     name: str
@@ -29,10 +30,6 @@ schema UpboundProviderConfigInput:
     prefix?: str    # Optional: Prefix for space-level access (when no group/ctp provided)
     providerConfigName: str  # Name of the provider config to reference
     upboundTokenSecretRef: UpboundTokenSecretRef        # Reference to the Upbound authentication token
-
-_metadata = lambda name: str -> any {
-    { annotations = { "krm.kcl.dev/composition-resource-name" = name }}
-}
 
 # Helper for generating a controlplane, space or group-level kubeconfig for provider-kubernetes on upbound
 # This function creates a kubeconfig that targets the appropriate API endpoint based on the scope:
@@ -144,7 +141,7 @@ upboundProviderConfig = lambda config: UpboundProviderConfigInput -> any {
    """
    [
         kubernetesv1alpha2.Object{
-            metadata = _metadata("{}Kubeconfig".format(resourceName(config.group, config.ctp))) | {
+            metadata = utils._metadata("{}Kubeconfig".format(resourceName(config.group, config.ctp))) | {
                 name = "{}-kubeconfig".format(configName(config.group, config.ctp, config.prefix))
             }
             spec = {
@@ -172,7 +169,7 @@ upboundProviderConfig = lambda config: UpboundProviderConfigInput -> any {
         }
 
         kubernetesv1alpha1.ProviderConfig{
-            metadata = _metadata("{}ProviderConfig".format(resourceName(config.group, config.ctp))) | {
+            metadata = utils._metadata("{}ProviderConfig".format(resourceName(config.group, config.ctp))) | {
                 name = configName(config.group, config.ctp, config.prefix)
                 annotations = {
                   "krm.kcl.dev/ready" = "True"
@@ -203,7 +200,7 @@ upboundProviderConfig = lambda config: UpboundProviderConfigInput -> any {
         {
             apiVersion = "apiextensions.crossplane.io/v1alpha1"
             kind = "Usage"
-            metadata = _metadata("{}Usage".format(resourceName(config.group, config.ctp))) | {
+            metadata = utils._metadata("{}Usage".format(resourceName(config.group, config.ctp))) | {
                 name = "{}-kubeconfig".format(configName(config.group, config.ctp, config.prefix))
             }
             spec = {

--- a/functions/xenvironments/teamRobot.k
+++ b/functions/xenvironments/teamRobot.k
@@ -13,6 +13,7 @@ This module handles the creation of Upbound team and robot resources for environ
 import models.io.crossplane.kubernetes.v1alpha2 as kubernetesv1alpha2
 import models.io.upbound.iam.v1alpha1 as iamv1alpha1
 import models.io.upbound.v1alpha1 as v1alpha1
+import utils
 
 schema TeamRobotTokenSecretRef:
     """
@@ -36,10 +37,6 @@ schema TeamWithRobotInput:
     teamExternalName?: str
     createGroupAdminBinding?: bool
 
-_metadata = lambda name: str -> any {
-    { annotations = { "krm.kcl.dev/composition-resource-name" = name }}
-}
-
 teamWithRobot = lambda input: TeamWithRobotInput -> any {
     """
     Creates team and robot resources for Upbound Space environments.
@@ -56,7 +53,7 @@ teamWithRobot = lambda input: TeamWithRobotInput -> any {
     [
         # ProviderConfig provider-upbound
         v1alpha1.ProviderConfig{
-            metadata =  _metadata("providerConfigUpbound") | {
+            metadata =  utils._metadata("providerConfigUpbound") | {
                 annotations = {
                   "krm.kcl.dev/ready" = "True"
                 }
@@ -77,7 +74,7 @@ teamWithRobot = lambda input: TeamWithRobotInput -> any {
 
         # Robot
         iamv1alpha1.Robot {
-            metadata = _metadata("envRobot") | {
+            metadata = utils._metadata("envRobot") | {
                 name = "{}-robot".format(input.group)
             }
             spec = {
@@ -96,7 +93,7 @@ teamWithRobot = lambda input: TeamWithRobotInput -> any {
         }
         # Robot Token
         iamv1alpha1.Token {
-            metadata = _metadata("envRobotToken") | {
+            metadata = utils._metadata("envRobotToken") | {
                 name = "{}-robot-token".format(input.group)
             }
             spec = {
@@ -120,7 +117,7 @@ teamWithRobot = lambda input: TeamWithRobotInput -> any {
         }
         # Team
         iamv1alpha1.Team {
-            metadata: _metadata("envTeam") | {
+            metadata: utils._metadata("envTeam") | {
                 name = "{}-team".format(input.group)
                 if input.teamExternalName:
                     annotations: {
@@ -141,7 +138,7 @@ teamWithRobot = lambda input: TeamWithRobotInput -> any {
         }
         # Robot team membership
         iamv1alpha1.RobotTeamMembership {
-            metadata = _metadata("envRobotTeamMembership") | {
+            metadata = utils._metadata("envRobotTeamMembership") | {
                 name = "{}-robot-team-membership".format(input.group)
             }
             spec = {
@@ -162,7 +159,7 @@ teamWithRobot = lambda input: TeamWithRobotInput -> any {
         # Grant admin rights on group to team
         if input.createGroupAdminBinding:
             kubernetesv1alpha2.Object{
-                metadata: _metadata("teamAdminBinding") | {
+                metadata: utils._metadata("teamAdminBinding") | {
                     name = "{}-admin-binding".format(input.group)
                 }
                 spec = {

--- a/functions/xenvironments/utils/metadata.k
+++ b/functions/xenvironments/utils/metadata.k
@@ -1,0 +1,12 @@
+_metadata = lambda name: str -> any {
+    """
+    Creates metadata with a standardized composition resource name.
+
+    Args:
+        name: The name to include in the annotations
+
+    Returns:
+        A metadata object with annotations for composition resource naming
+    """
+    { annotations = { "krm.kcl.dev/composition-resource-name" = name }}
+}

--- a/functions/xenvironments/utils/secret.k
+++ b/functions/xenvironments/utils/secret.k
@@ -1,0 +1,28 @@
+import models.io.crossplane.kubernetes.v1alpha2 as kubernetesv1alpha2
+import kube.api.core.v1 as v1
+
+observeSecret = lambda config: ObserveSecret -> any {
+   """
+   Observe a Secret.
+   """
+   [
+        kubernetesv1alpha2.Object{
+            metadata = _metadata(config.resourceName) | {
+                name = "{}-{}-observed".format(config.ctp, config.resourceName)
+            }
+            spec = {
+                forProvider = {
+                    manifest = v1.Secret{
+                        metadata = {
+                            name = config.name
+                            namespace = config.namespace
+                        }
+                    }
+                }
+                providerConfigRef = {
+                    name = config.providerConfigName
+                }
+                managementPolicies = ["Observe"]
+            }
+        }
+]}

--- a/functions/xenvironments/utils/secretSchema.k
+++ b/functions/xenvironments/utils/secretSchema.k
@@ -1,0 +1,24 @@
+schema ObserveSecret:
+    r"""
+    ObserveSecret represents an Input for an Observe Secret.
+
+    Attributes
+    ----------
+    name : str, required
+        The metadata.name of the observed secret.
+    namespace : str, required
+        The metadata.namespace of the observed secret.
+    ctp : str, required
+        The control plane name for control plane-level access
+    resourceName : str, required
+        The crossplane.io/composition-resource-name for the observed secret.
+    providerConfigName : str, required
+        The Name of the provider config to reference
+    """
+
+    name: str
+    namespace: str
+    ctp: str
+    resourceName: str
+    providerConfigName: str
+

--- a/functions/xupboundreposet/main.k
+++ b/functions/xupboundreposet/main.k
@@ -17,20 +17,16 @@ Parameters:
 import models.io.upbound.sa.v1 as sav1
 import models.io.upbound.repository.v1alpha1 as repositoryv1alpha1
 import models.io.upbound.v1alpha1 as v1alpha1
+import utils
 
 # Extract the XUpboundRepoSet object from the parameters
 oxr = sav1.XUpboundRepoSet{**option("params").oxr}
-
-# Helper function to create metadata with composition resource name annotation
-_metadata = lambda name: str -> any {
-    { annotations = { "krm.kcl.dev/composition-resource-name" = name }}
-}
 
 # Generate list of resources to create
 _items = [
     # Create Repository resources for each repository specified in the parameters
     repositoryv1alpha1.Repository{
-        metadata: _metadata("{}-{}".format(oxr.spec.parameters.organization, repo)) | {
+        metadata: utils._metadata("{}-{}".format(oxr.spec.parameters.organization, repo)) | {
             annotations: {
                 "crosslane.io/external-name": repo
             }
@@ -53,7 +49,7 @@ _items = [
     # Create Permission resources connecting teams to repositories with specified permission levels
     # This creates a Permission resource for each repository and team combination
     repositoryv1alpha1.Permission{
-        metadata: _metadata("{}-{}-{}".format(oxr.spec.parameters.organization, repo, team))
+        metadata: utils._metadata("{}-{}-{}".format(oxr.spec.parameters.organization, repo, team))
         spec = {
             forProvider = {
                 organizationName = oxr.spec.parameters.organization
@@ -72,7 +68,7 @@ _items = [
     } for repo in oxr.spec.parameters.repositories for team in oxr.spec.parameters.permissions?.teams
 ] + [
     v1alpha1.ProviderConfig{
-        metadata: _metadata("providerConfigUpbound") | {
+        metadata: utils._metadata("providerConfigUpbound") | {
             annotations: {
               "krm.kcl.dev/ready" = "True"
             }

--- a/functions/xupboundreposet/utils/metadata.k
+++ b/functions/xupboundreposet/utils/metadata.k
@@ -1,0 +1,12 @@
+_metadata = lambda name: str -> any {
+    """
+    Creates metadata with a standardized composition resource name.
+
+    Args:
+        name: The name to include in the annotations
+
+    Returns:
+        A metadata object with annotations for composition resource naming
+    """
+    { annotations = { "krm.kcl.dev/composition-resource-name" = name }}
+}

--- a/tests/test-xenvironment/main.k
+++ b/tests/test-xenvironment/main.k
@@ -4,7 +4,8 @@ import models.io.upbound.aws.iam.v1beta1 as iamv1beta1
 import models.io.upbound.aws.secretsmanager.v1beta1 as secretsmanagerv1beta1
 import models.io.upbound.aws.v1beta1 as awsv1beta1
 import models.io.upbound.dev.meta.v1alpha1 as metav1alpha1
-import models.io.upbound.sa.v1 as sav1
+import json
+import base64
 
 
 _items = [
@@ -585,6 +586,74 @@ _items = [
                     }
                 }
 
+                kubernetesv1alpha2.Object{
+                    metadata = {
+                        name = "example-observed-access-token-observed"
+                    }
+                    spec = {
+                        forProvider = {
+                            manifest = {
+                                apiVersion = "v1"
+                                kind = "Secret"
+                                metadata = {
+                                    name = "upbound-token"
+                                    namespace = "default"
+                                }
+                            }
+                        }
+                        managementPolicies = [
+                            "Observe"
+                        ]
+                        providerConfigRef = {
+                            name = "bootstrap-ctp"
+                        }
+                    }
+                }
+
+                kubernetesv1alpha2.Object{
+                    metadata = {
+                        name = "example-ctp-argocd-secret"
+                    }
+                    spec = {
+                        forProvider = {
+                            manifest = {
+                                apiVersion: "v1"
+                                kind: "Secret"
+                                metadata: {
+                                    name: "solutions-non-prod-example-example"
+                                    namespace: "argocd"
+                                    labels: {
+                                        "argocd.argoproj.io/secret-type": "cluster"
+                                    }
+                                }
+                                type: "Opaque"
+                                stringData: {
+                                    name: "solutions-non-prod-example-example"
+                                    server: "https://upbound-aws-us-east-1.space.mxe.upbound.io/apis/spaces.upbound.io/v1beta1/namespaces/solutions-non-prod-example/controlplanes/example/k8s"
+                                    config: json.encode({
+                                        execProviderConfig: {
+                                            apiVersion: "client.authentication.k8s.io/v1"
+                                            command: "up"
+                                            args: [
+                                                "org"
+                                                "token"
+                                            ]
+                                            env: {
+                                                "ORGANIZATION": "upbound"
+                                                "UP_TOKEN": "uptest-token"
+                                            }
+                                        }
+                                        tlsClientConfig: {
+                                            insecure: False
+                                            caData: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJ6ekNDQVhTZ0F3SUJBZ0lSQUtuaU1IS1lkN01oQUJDbzMxRHI3cDh3Q2dZSUtvWkl6ajBFQXdJd056RUwKTUFrR0ExVUVCaE1DVlZNeEVEQU9CZ05WQkFvVEIzVndZbTkxYm1ReEZqQVVCZ05WQkFNVERWVndZbTkxYm1RcwpJRWx1WXk0d0hoY05NalV3TXpBeU1EQXpPVE0wV2hjTk1qWXdNekF5TURBek9UTTBXakEzTVFzd0NRWURWUVFHCkV3SlZVekVRTUE0R0ExVUVDaE1IZFhCaWIzVnVaREVXTUJRR0ExVUVBeE1OVlhCaWIzVnVaQ3dnU1c1akxqQloKTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEEwSUFCTTUyUE5BWFNuQ0pHNzdWbmU2K01VVWllSW5SdmR4YQpOaDlqeW5NS3RMM2QrdWNTMTQ0R3ZLbFpiS3l1dXZzZDhrSkJyZWg3V1A3Sk9pcDFyRmU1T2d5allUQmZNQTRHCkExVWREd0VCL3dRRUF3SUJwakFkQmdOVkhTVUVGakFVQmdnckJnRUZCUWNEQVFZSUt3WUJCUVVIQXdJd0R3WUQKVlIwVEFRSC9CQVV3QXdFQi96QWRCZ05WSFE0RUZnUVUydmJKZTBVbzJjMmlsODdXOGhISWRUdHZVeWd3Q2dZSQpLb1pJemowRUF3SURTUUF3UmdJaEFLSDlLTWFHelVjcVo3NHR1aVI5VFd6S2tnakRMNWlTRWZmM0ZENktaZy9PCkFpRUFwVU8yMGZtRU9Ua0hsUHN2MTh2T1VVby8rRWJnSXo3M00waG5VQysySFJFPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+                                        }
+                                    })
+                                }
+                            }
+                        }
+                    }
+                }
+
                 kubernetesv1alpha1.ProviderConfig{
                     metadata = {
                         name = "example-space"
@@ -613,35 +682,39 @@ _items = [
             compositionPath: "apis/xenvironments/composition.yaml"
             xrPath: "examples/xenvironment/example.yaml"
             xrdPath: "apis/xenvironments/definition.yaml"
-            context: []
-            extraResources: [
-                sav1.XEnvironment{
+            observedResources = [
+                kubernetesv1alpha2.Object{
                     metadata = {
-                        name = "example"
-                    }
-                    spec = {}
-                    status = {
-                        upbound = {
-                            bootstrapCtp = "foo"
-                            bootstrapGroup = "bar"
-                            org = "upbound"
-                            spaceHost = "foo"
+                        name = "example-observed-access-token-observed"
+                        annotations: {
+                            "crossplane.io/composition-resource-name": "observed-access-token"
                         }
                     }
-                }
-            ]
-            observedResources = [
-                sav1.XEnvironment{
-                    metadata = {
-                        name = "example"
+                    spec = {
+                        forProvider = {
+                            manifest = {
+                                apiVersion = "v1"
+                                kind = "Secret"
+                                metadata = {
+                                    name = "upbound-token"
+                                    namespace = "default"
+                                }
+                            }
+                        }
+                        managementPolicies = [
+                            "Observe"
+                        ]
+                        providerConfigRef = {
+                            name = "bootstrap-ctp"
+                        }
                     }
-                    spec = {}
                     status = {
-                        upbound = {
-                            bootstrapCtp = "foo"
-                            bootstrapGroup = "bar"
-                            org = "upbound"
-                            spaceHost = "foo"
+                        atProvider = {
+                            manifest = {
+                                data = {
+                                    token = base64.encode("uptest-token")
+                                }
+                            }
                         }
                     }
                 }
@@ -664,7 +737,7 @@ _items = [
                         atProvider = {
                             manifest = {
                                 data = {
-                                    kubeconfig = "YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGluc2VjdXJlLXNraXAtdGxzLXZlcmlmeTogdHJ1ZQogICAgc2VydmVyOiBodHRwczovL3VwYm91bmQtYXdzLXVzLWVhc3QtMS5zcGFjZS5teGUudXBib3VuZC5pby9hcGlzL3NwYWNlcy51cGJvdW5kLmlvL3YxYmV0YTEvbmFtZXNwYWNlcy9zb2x1dGlvbnMtbm9uLXByb2QvY29udHJvbHBsYW5lcy9ib290c3RyYXAvazhzCiAgbmFtZTogdXBib3VuZApjb250ZXh0czoKLSBjb250ZXh0OgogICAgY2x1c3RlcjogdXBib3VuZAogICAgZXh0ZW5zaW9uczoKICAgIC0gZXh0ZW5zaW9uOgogICAgICAgIGFwaVZlcnNpb246IHVwYm91bmQuaW8vdjFhbHBoYTEKICAgICAgICBraW5kOiBTcGFjZUV4dGVuc2lvbgogICAgICAgIHNwZWM6CiAgICAgICAgICBjbG91ZDoKICAgICAgICAgICAgb3JnYW5pemF0aW9uOiB1cGJvdW5kCiAgICAgIG5hbWU6IHNwYWNlcy51cGJvdW5kLmlvL3NwYWNlCiAgICBuYW1lc3BhY2U6IGRlZmF1bHQKICAgIHVzZXI6IHVwYm91bmQKICBuYW1lOiB1cGJvdW5kCmN1cnJlbnQtY29udGV4dDogdXBib3VuZApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHVwYm91bmQKICB1c2VyOgogICAgZXhlYzoKICAgICAgYXBpVmVyc2lvbjogY2xpZW50LmF1dGhlbnRpY2F0aW9uLms4cy5pby92MQogICAgICBhcmdzOgogICAgICAtIG9yZ2FuaXphdGlvbgogICAgICAtIHRva2VuCiAgICAgIGNvbW1hbmQ6IHVwCiAgICAgIGVudjoKICAgICAgLSBuYW1lOiBPUkdBTklaQVRJT04KICAgICAgICB2YWx1ZTogdXBib3VuZAogICAgICAtIG5hbWU6IFVQX1BST0ZJTEUKICAgICAgICB2YWx1ZTogZGVmYXVsdAogICAgICBpbnRlcmFjdGl2ZU1vZGU6IElmQXZhaWxhYmxlCiAgICAgIHByb3ZpZGVDbHVzdGVySW5mbzogZmFsc2UK"
+                                    kubeconfig = "YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VKNmVrTkRRVmhUWjBGM1NVSkJaMGxTUVV0dWFVMUlTMWxrTjAxb1FVSkRiek14UkhJM2NEaDNRMmRaU1V0dldrbDZhakJGUVhkSmQwNTZSVXdLVFVGclIwRXhWVVZDYUUxRFZsWk5lRVZFUVU5Q1owNVdRa0Z2VkVJelZuZFpiVGt4WW0xUmVFWnFRVlZDWjA1V1FrRk5WRVJXVm5kWmJUa3hZbTFSY3dwSlJXeDFXWGswZDBob1kwNU5hbFYzVFhwQmVVMUVRWHBQVkUwd1YyaGpUazFxV1hkTmVrRjVUVVJCZWs5VVRUQlhha0V6VFZGemQwTlJXVVJXVVZGSENrVjNTbFpWZWtWUlRVRTBSMEV4VlVWRGFFMUlaRmhDYVdJelZuVmFSRVZYVFVKUlIwRXhWVVZCZUUxT1ZsaENhV0l6Vm5WYVEzZG5VMWMxYWt4cVFsb0tUVUpOUjBKNWNVZFRUVFE1UVdkRlIwTkRjVWRUVFRRNVFYZEZTRUV3U1VGQ1RUVXlVRTVCV0ZOdVEwcEhOemRXYm1VMkswMVZWV2xsU1c1U2RtUjRZUXBPYURscWVXNU5TM1JNTTJRcmRXTlRNVFEwUjNaTGJGcGlTM2wxZFhaelpEaHJTa0p5WldnM1YxQTNTazlwY0RGeVJtVTFUMmQ1YWxsVVFtWk5RVFJIQ2tFeFZXUkVkMFZDTDNkUlJVRjNTVUp3YWtGa1FtZE9Wa2hUVlVWR2FrRlZRbWRuY2tKblJVWkNVV05FUVZGWlNVdDNXVUpDVVZWSVFYZEpkMFIzV1VRS1ZsSXdWRUZSU0M5Q1FWVjNRWGRGUWk5NlFXUkNaMDVXU0ZFMFJVWm5VVlV5ZG1KS1pUQlZiekpqTW1sc09EZFhPR2hJU1dSVWRIWlZlV2QzUTJkWlNRcExiMXBKZW1vd1JVRjNTVVJUVVVGM1VtZEphRUZMU0RsTFRXRkhlbFZqY1ZvM05IUjFhVkk1VkZkNlMydG5ha1JNTldsVFJXWm1NMFpFTmt0YVp5OVBDa0ZwUlVGd1ZVOHlNR1p0UlU5VWEwaHNVSE4yTVRoMlQxVlZieThyUldKblNYbzNNMDB3YUc1VlF5c3lTRkpGUFFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL3VwYm91bmQtYXdzLXVzLWVhc3QtMS5zcGFjZS5teGUudXBib3VuZC5pby9hcGlzL3NwYWNlcy51cGJvdW5kLmlvL3YxYmV0YTEvbmFtZXNwYWNlcy9zb2x1dGlvbnMtbm9uLXByb2QvY29udHJvbHBsYW5lcy9ib290c3RyYXAvazhzCiAgbmFtZTogdXBib3VuZApjb250ZXh0czoKLSBjb250ZXh0OgogICAgY2x1c3RlcjogdXBib3VuZAogICAgZXh0ZW5zaW9uczoKICAgIC0gZXh0ZW5zaW9uOgogICAgICAgIGFwaVZlcnNpb246IHVwYm91bmQuaW8vdjFhbHBoYTEKICAgICAgICBraW5kOiBTcGFjZUV4dGVuc2lvbgogICAgICAgIHNwZWM6CiAgICAgICAgICBjbG91ZDoKICAgICAgICAgICAgb3JnYW5pemF0aW9uOiB1cGJvdW5kCiAgICAgIG5hbWU6IHNwYWNlcy51cGJvdW5kLmlvL3NwYWNlCiAgICBuYW1lc3BhY2U6IGRlZmF1bHQKICAgIHVzZXI6IHVwYm91bmQKICBuYW1lOiB1cGJvdW5kCmN1cnJlbnQtY29udGV4dDogdXBib3VuZApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHVwYm91bmQKICB1c2VyOgogICAgZXhlYzoKICAgICAgYXBpVmVyc2lvbjogY2xpZW50LmF1dGhlbnRpY2F0aW9uLms4cy5pby92MQogICAgICBhcmdzOgogICAgICAtIG9yZ2FuaXphdGlvbgogICAgICAtIHRva2VuCiAgICAgIGNvbW1hbmQ6IHVwCiAgICAgIGVudjoKICAgICAgLSBuYW1lOiBPUkdBTklaQVRJT04KICAgICAgICB2YWx1ZTogdXBib3VuZAogICAgICAtIG5hbWU6IFVQX1BST0ZJTEUKICAgICAgICB2YWx1ZTogZGVmYXVsdAogICAgICBpbnRlcmFjdGl2ZU1vZGU6IElmQXZhaWxhYmxlCiAgICAgIHByb3ZpZGVDbHVzdGVySW5mbzogZmFsc2UK"
                                 }
                             }
                         }


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
- switched _metadata to utils
- add option to create argo server secrets
- add utils function to create observed secrets with provider kubernetes objects
- updated tests

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested
- updated composition tests
- bootstrapped a full environment 


```
kubectl get secrets -n argocd
NAME                                    TYPE                 DATA   AGE
[...]
solution-idp-non-prod-ai-ai             Opaque               3      84m
solution-idp-non-prod-compute-compute   Opaque               3      84m
solution-idp-non-prod-db-db             Opaque               3      84m
solution-idp-non-prod-iam-iam           Opaque               3      84m
solution-idp-non-prod-network-network   Opaque               3      84m
```

```
kubectl get applications -A
NAMESPACE   NAME                                    SYNC STATUS   HEALTH STATUS
argocd      solution-idp-non-prod                   Synced        Healthy
argocd      solution-idp-non-prod-compute-compute   Synced        Healthy
argocd      solution-idp-non-prod-db-db             Synced        Healthy
argocd      solution-idp-non-prod-network-network   Synced        Healthy
```

```
up ctx
Switched kubeconfig context to: Upbound upbound/space-the-final-frontier/solution-idp-non-prod-compute/compute
kubectl get configurations
NAME                                INSTALLED   HEALTHY   PACKAGE                                                     AGE
configuration-aws-eks               True        True      xpkg.upbound.io/upbound/configuration-aws-eks:v0.17.0       6m53s
upbound-configuration-aws-network   True        True      xpkg.upbound.io/upbound/configuration-aws-network:v0.24.0   6m52s
```

```
up ctx
Switched kubeconfig context to: Upbound upbound/space-the-final-frontier/solution-idp-non-prod-db/db
kubectl get configurations
NAME                                INSTALLED   HEALTHY   PACKAGE                                                      AGE
configuration-aws-database          True        True      xpkg.upbound.io/upbound/configuration-aws-database:v0.16.0   7m30s
upbound-configuration-aws-network   True        True      xpkg.upbound.io/upbound/configuration-aws-network:v0.24.0    7m26s
```

```
up ctx
Switched kubeconfig context to: Upbound upbound/space-the-final-frontier/solution-idp-non-prod-network/network
kubectl get configurations
NAME                        INSTALLED   HEALTHY   PACKAGE                                                     AGE
configuration-aws-network   True        True      xpkg.upbound.io/upbound/configuration-aws-network:v0.24.0   14m
```


<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
